### PR TITLE
Changed terraform label module source url to aws-quickstart one

### DIFF
--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 #}
 
 module "quickstart_vpc_label" {
-  source    = "git@github.com:SushantJagdale/terraform-aws-label-1.git?ref=develop"
+  source    = "git@github.com:aws-quickstart/terraform-aws-label.git"
   region    = var.region
   namespace = var.namespace
   env       = var.env


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: 

Changed terraform-aws-label source URL to official aws-quickstart terraform-aws-label repo.

@tonynv  I noticed that the earlier PR which I raised (https://github.com/aws-quickstart/terraform-aws-vpc/pull/18), you have merged with main branch. I wanted to check if we need to test the other terraform quickstart repos like aurora which uses aws-quickstart terraform aws-vpc repo. In that case, should we have my PR merged to develop branch of terraform-aws-vpc repo first?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
